### PR TITLE
Correct docs file

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,2 +1,2 @@
 NEWS
-README
+README.md


### PR DESCRIPTION
Needed to change `README` to `README.md`. Otherwise trying to build the deb package with `sudo debuild -b -uc -us` fails with 
```
install -D -m 0644 conf/logrotate.conf /home/aggelis/temp_build/pepsal/debian/pepsal/etc/logrotate.d/pepsal.conf
make[1]: Leaving directory '/home/aggelis/temp_build/pepsal'
   dh_installdocs
dh_installdocs: error: Cannot find (any matches for) "README" (tried in .)

make: *** [debian/rules:21: binary] Error 25
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
debuild: fatal error at line 1182:

```